### PR TITLE
fix issue with pwmSetIndex blatting LED data

### DIFF
--- a/LRAS1130Picture12x11.cpp
+++ b/LRAS1130Picture12x11.cpp
@@ -74,8 +74,8 @@ bool AS1130Picture12x11::getPixel(uint8_t x, uint8_t y)
 void AS1130Picture12x11::writeRegisters(uint8_t *registerData, const uint8_t *rawData, uint8_t pwmSetIndex)
 {
   std::memset(registerData, 0, 0x18);
-  for (uint8_t x = 0; x < getWidth(); x++) {
-    for (uint8_t y = 0; y < getHeight(); y++) {
+  for (uint8_t x = 0; x < getWidth(); ++x) {
+    for (uint8_t y = 0; y < getHeight(); ++y) {
       if ((rawData[getDataIndex(x, y)] & getDataBit(x,y)) != 0) {
         registerData[(x*2)+(y/8)] |= (1<<(x&7));
       }

--- a/LRAS1130Picture12x11.cpp
+++ b/LRAS1130Picture12x11.cpp
@@ -74,14 +74,14 @@ bool AS1130Picture12x11::getPixel(uint8_t x, uint8_t y)
 void AS1130Picture12x11::writeRegisters(uint8_t *registerData, const uint8_t *rawData, uint8_t pwmSetIndex)
 {
   std::memset(registerData, 0, 0x18);
-  for (uint8_t x = 0; x < getWidth(); ++x) {
-    for (uint8_t y = 0; y < getHeight(); ++y) {
+  for (uint8_t x = 0; x < getWidth(); x++) {
+    for (uint8_t y = 0; y < getHeight(); y++) {
       if ((rawData[getDataIndex(x, y)] & getDataBit(x,y)) != 0) {
         registerData[(x*2)+(y/8)] |= (1<<(x&7));
       }
     }
   }
-  registerData[1] = (pwmSetIndex<<5);
+  registerData[1] |= (pwmSetIndex<<5);
 }
 
 

--- a/LRAS1130Picture24x5.cpp
+++ b/LRAS1130Picture24x5.cpp
@@ -74,8 +74,8 @@ bool AS1130Picture24x5::getPixel(uint8_t x, uint8_t y)
 void AS1130Picture24x5::writeRegisters(uint8_t *registerData, const uint8_t *rawData, uint8_t pwmSetIndex)
 {
   std::memset(registerData, 0, 0x18);
-  for (uint8_t x = 0; x < getWidth(); x++) {
-    for (uint8_t y = 0; y < getHeight(); y++) {
+  for (uint8_t x = 0; x < getWidth(); ++x) {
+    for (uint8_t y = 0; y < getHeight(); ++y) {
       if ((rawData[getDataIndex(x, y)] & getDataBit(x,y)) != 0) {
         const uint8_t ledIndex = (x*5+y);
         const uint8_t registerBitIndex = ledIndex%10;

--- a/LRAS1130Picture24x5.cpp
+++ b/LRAS1130Picture24x5.cpp
@@ -74,8 +74,8 @@ bool AS1130Picture24x5::getPixel(uint8_t x, uint8_t y)
 void AS1130Picture24x5::writeRegisters(uint8_t *registerData, const uint8_t *rawData, uint8_t pwmSetIndex)
 {
   std::memset(registerData, 0, 0x18);
-  for (uint8_t x = 0; x < getWidth(); ++x) {
-    for (uint8_t y = 0; y < getHeight(); ++y) {
+  for (uint8_t x = 0; x < getWidth(); x++) {
+    for (uint8_t y = 0; y < getHeight(); y++) {
       if ((rawData[getDataIndex(x, y)] & getDataBit(x,y)) != 0) {
         const uint8_t ledIndex = (x*5+y);
         const uint8_t registerBitIndex = ledIndex%10;
@@ -84,7 +84,7 @@ void AS1130Picture24x5::writeRegisters(uint8_t *registerData, const uint8_t *raw
       }
     }
   }
-  registerData[1] = (pwmSetIndex<<5);
+  registerData[1] |= (pwmSetIndex<<5);
 }
 
 


### PR DESCRIPTION
Ran into an issue playing around with `AS1130Picture24x5` - see [here](https://github.com/tardate/LittleArduinoProjects/blob/master/BoldportClub/TheMatrix/LedTest/LedTest.ino#L78), 

I could get all pixels to light except `setPixel(1,3, true)` and  `setPixel(1,4, true)`. After digging around a little, it turned out to be because the `AS1130Picture24x5::writeRegisters` overwrites some led data when it sets the PWM set: `registerData[1] = (pwmSetIndex<<5);`

I've also fixed this for `AS1130Picture12x11` - seems to have the same issue, though I haven't used this class in practice.

Thanks for the library .. it's a great way to learn about the AS1130!