### PR TITLE
Restrict maximum number of I2C bytes send in one transmission.

### DIFF
--- a/LRAS1130.cpp
+++ b/LRAS1130.cpp
@@ -67,6 +67,10 @@ namespace {
 const uint8_t cRegisterSelectionAddress = 0xfd;
 
   
+/// Use buffer length defined by the Wire library to send data in blocks
+///
+const uint8_t cMaxWireDataBytes = BUFFER_LENGTH - 2;
+
 }
 
 
@@ -495,12 +499,15 @@ void AS1130::writeToMemory(uint8_t registerSelection, uint8_t address, const uin
 void AS1130::fillMemory(uint8_t registerSelection, uint8_t address, uint8_t value, uint8_t size)
 {
   writeToChip(cRegisterSelectionAddress, registerSelection);
-  Wire.beginTransmission(_chipAddress);
-  Wire.write(address); 
-  for (uint8_t i = 0; i < size; ++i) {
-    Wire.write(value);
-  }  
-  Wire.endTransmission();   
+  while (size > 0) {
+    Wire.beginTransmission(_chipAddress);
+    Wire.write(address);
+    for (uint8_t i = 0; size > 0 && i < cMaxWireDataBytes; ++i, --size) {
+      Wire.write(value);
+    }
+    address += cMaxWireDataBytes;
+    Wire.endTransmission();
+  }
 }
 
 


### PR DESCRIPTION
I had the issue that some of the LEDs did not light as bright as the others when using the Arduino library, but the same effect did not happen with the Raspberry Pi sample code.

After some digging, I think the cause is a limitation of the Wire library. While the AS1130 datasheet states an unlimited number of data bytes per I2C transmission the Wire library uses an internal buffer of 32 bytes (`BUFFER_LENGTH` in `Wire.h`).

The patch changes the `fillMemory()` method to split transfers which fixes the issue for me on a Leonardo board.

I've tested with the following code added to the LED-Test example:
```
void loop() {
  for (int a = 0;a < 10;a++) {
    ledDriver.setBlinkAndPwmSetAll(0, 0, 10);
    delay(200);
    ledDriver.setBlinkAndPwmSetAll(0, 0, 255);
    delay(200);
  }
  delay(1000);
}
```